### PR TITLE
the package doesn't pip install without version and with non-existant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,21 +10,24 @@ import os
 from setuptools import setup
 
 _name = "local_volume_database"
-_version = ""
+_version = "0.0.1"
 
 setup(
     name=_name,
     version=_version,
     author='Andrew B. Pace',
     author_email='pvpace1@gmail.com',
-    packages=['local_volume_database'],
-    package_data={'data/':['*.csv'],},
+    packages=[],  # 'local_volume_database',
+    package_data={
+        'data/': ['*.csv'],
+    },
     url='https://github.com/apace7/local_volume_database',
     license='LICENSE',
-    description='Database of the properties of local field dwarf galaxies and Milky Way Star Cluster',
+    description=
+    'Database of the properties of local field dwarf galaxies and Milky Way Star Cluster',
     long_description=open('README.md').read(),
     install_requires=[
-      "numpy",
-      "astropy",
+        "numpy",
+        "astropy",
     ],
 )


### PR DESCRIPTION
the package currently doesn't pip install without version and with non-existent package directory
the patch fixes that

```
$ pip install -U ../local_volume_database/
Processing /home/skoposov/science/local_volume_database
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [24 lines of output]
      /home/skoposov/pyenv_dir/pyenv310/lib/python3.10/site-packages/setuptools/dist.py:509: SetuptoolsDeprecationWarning: Invalid version: ''.
      !!
      
````