### PR TITLE
Fix RA/DEC of Balbinot 1

### DIFF
--- a/data_input/balbinot_1.yaml
+++ b/data_input/balbinot_1.yaml
@@ -1,8 +1,8 @@
 key: balbinot_1
 table: gc_ambiguous
 location:
-  dec: 14.9403
-  ra: 332.6791
+  dec: 14.9496
+  ra: 332.6797
 name_discovery:
   confirmed_real: 1
   confirmed_star_cluster: 0


### PR DESCRIPTION
Not sure the source of the error, but the declination of Balbinot~1 was slightly off. Now fixed for this specific case only, but we should be wary of an underlying issue.