### PR TITLE
Fixed ellipticity and PA for NGC 300 to match reference

### DIFF
--- a/data_input/ngc_0300.yaml
+++ b/data_input/ngc_0300.yaml
@@ -34,7 +34,7 @@ structure:
   ellipticity: 0.29
   ellipticity_em: 0.01
   ellipticity_ep: 0.01
-  position_angle: 108.0
+  position_angle: 111.0
   position_angle_em: 2.0
   position_angle_ep: 2.0
   ref_structure: McConnachie2012AJ....144....4M

--- a/data_input/ngc_0300.yaml
+++ b/data_input/ngc_0300.yaml
@@ -31,7 +31,7 @@ m_v:
   apparent_magnitude_v_ep: 0.1
   ref_m_v: McConnachie2012AJ....144....4M
 structure:
-  ellipticity: 0.83
+  ellipticity: 0.29
   ellipticity_em: 0.01
   ellipticity_ep: 0.01
   position_angle: 108.0


### PR DESCRIPTION
I noticed that the ellipse defined by the current NGC300 entry does not seem to match the Gaia data distribution of stars on the sky. I went back to the original reference (McConnachie2012AJ....144....4M) and confirmed that the Table 3 results indeed show a much smaller ellipticity. I also noticed the PA was off by a couple degrees. 