### PR TITLE
Update NGC 147, 185 with Crnojevic2014 values

### DIFF
--- a/data_input/ngc_0147.yaml
+++ b/data_input/ngc_0147.yaml
@@ -51,6 +51,8 @@ structure:
   position_angle_em: 3.6
   position_angle_ep: 3.6
   rhalf: 6.7
+  rhalf_em: 0.09
+  rhalf_ep: 0.09
   ref_structure: Crnojević2014MNRAS.445.3862C
 structure_sersic:
   n_sersic: 1.69
@@ -65,9 +67,6 @@ structure_sersic:
   position_angle: 34.2
   position_angle_em: 3.6
   position_angle_ep: 3.6
-  central_surface_brightness: 24.15
-  central_surface_brightness_em: 0.03
-  central_surface_brightness_ep: 0.03
   ref_structure_sersic: Crnojević2014MNRAS.445.3862C
 velocity:
   ref_vlos: McConnachie2012AJ....144....4M

--- a/data_input/ngc_0147.yaml
+++ b/data_input/ngc_0147.yaml
@@ -34,7 +34,7 @@ m_v:
   apparent_magnitude_v: 7.76
   apparent_magnitude_v_em: 0.04
   apparent_magnitude_v_ep: 0.04
-  ref_m_v: Crnojević2014MNRAS.445.3862C
+  ref_m_v: Crnojevic2014MNRAS.445.3862C
 proper_motion:
   pmra: 0.0232
   pmra_em: 0.0143
@@ -53,7 +53,7 @@ structure:
   rhalf: 6.7
   rhalf_em: 0.09
   rhalf_ep: 0.09
-  ref_structure: Crnojević2014MNRAS.445.3862C
+  ref_structure: Crnojevic2014MNRAS.445.3862C
 structure_sersic:
   n_sersic: 1.69
   n_sersic_em: 0.03
@@ -67,7 +67,7 @@ structure_sersic:
   position_angle: 34.2
   position_angle_em: 3.6
   position_angle_ep: 3.6
-  ref_structure_sersic: Crnojević2014MNRAS.445.3862C
+  ref_structure_sersic: Crnojevic2014MNRAS.445.3862C
 velocity:
   ref_vlos: McConnachie2012AJ....144....4M
   vlos_sigma: 16.0

--- a/data_input/ngc_0147.yaml
+++ b/data_input/ngc_0147.yaml
@@ -31,10 +31,10 @@ flux_HI:
   flux_HI_ul: 0.62
   ref_flux_HI: Putman2021ApJ...913...53P
 m_v:
-  apparent_magnitude_v: 9.5
-  apparent_magnitude_v_em: 0.1
-  apparent_magnitude_v_ep: 0.1
-  ref_m_v: McConnachie2012AJ....144....4M
+  apparent_magnitude_v: 7.76
+  apparent_magnitude_v_em: 0.04
+  apparent_magnitude_v_ep: 0.04
+  ref_m_v: Crnojević2014MNRAS.445.3862C
 proper_motion:
   pmra: 0.0232
   pmra_em: 0.0143
@@ -44,14 +44,31 @@ proper_motion:
   pmdec_ep: 0.0146
   ref_proper_motion: Sohn2020ApJ...901...43S
 structure:
-  ellipticity: 0.41
+  ellipticity: 0.46
   ellipticity_em: 0.02
   ellipticity_ep: 0.02
-  position_angle: 25.0
-  position_angle_em: 3.0
-  position_angle_ep: 3.0
-  ref_structure: McConnachie2012AJ....144....4M
-  rhalf: 3.17
+  position_angle: 34.2
+  position_angle_em: 3.6
+  position_angle_ep: 3.6
+  rhalf: 6.7
+  ref_structure: Crnojević2014MNRAS.445.3862C
+structure_sersic:
+  n_sersic: 1.69
+  n_sersic_em: 0.03
+  n_sersic_ep: 0.03
+  rad_sersic: 6.70
+  rad_sersic_em: 0.09
+  rad_sersic_ep: 0.09
+  ellipticity: 0.46
+  ellipticity_em: 0.02
+  ellipticity_ep: 0.02
+  position_angle: 34.2
+  position_angle_em: 3.6
+  position_angle_ep: 3.6
+  central_surface_brightness: 24.15
+  central_surface_brightness_em: 0.03
+  central_surface_brightness_ep: 0.03
+  ref_structure_sersic: Crnojević2014MNRAS.445.3862C
 velocity:
   ref_vlos: McConnachie2012AJ....144....4M
   vlos_sigma: 16.0

--- a/data_input/ngc_0185.yaml
+++ b/data_input/ngc_0185.yaml
@@ -32,7 +32,7 @@ m_v:
   apparent_magnitude_v: 8.46
   apparent_magnitude_v_em: 0.04
   apparent_magnitude_v_ep: 0.04
-  ref_m_v: Crnojević2014MNRAS.445.3862C
+  ref_m_v: Crnojevic2014MNRAS.445.3862C
 proper_motion:
   pmdec: 0.0058
   pmdec_em: 0.0147
@@ -51,7 +51,7 @@ structure:
   rhalf: 2.94
   rhalf_em: 0.04
   rhalf_ep: 0.04
-  ref_structure: Crnojević2014MNRAS.445.3862C
+  ref_structure: Crnojevic2014MNRAS.445.3862C
 structure_sersic:
   n_sersic: 1.78
   n_sersic_em: 0.02
@@ -65,7 +65,7 @@ structure_sersic:
   rad_sersic: 2.94
   rad_sersic_em: 0.04
   rad_sersic_ep: 0.04
-  ref_structure_sersic: Crnojević2014MNRAS.445.3862C
+  ref_structure_sersic: Crnojevic2014MNRAS.445.3862C
 velocity:
   ref_vlos: McConnachie2012AJ....144....4M
   vlos_sigma: 24.0

--- a/data_input/ngc_0185.yaml
+++ b/data_input/ngc_0185.yaml
@@ -29,10 +29,10 @@ flux_HI:
   flux_HI_ep: 0.11
   ref_flux_HI: Putman2021ApJ...913...53P
 m_v:
-  apparent_magnitude_v: 9.2
-  apparent_magnitude_v_em: 0.1
-  apparent_magnitude_v_ep: 0.1
-  ref_m_v: McConnachie2012AJ....144....4M
+  apparent_magnitude_v: 8.76
+  apparent_magnitude_v_em: 0.04
+  apparent_magnitude_v_ep: 0.04
+  ref_m_v: Crnojević2014MNRAS.445.3862C
 proper_motion:
   pmdec: 0.0058
   pmdec_em: 0.0147
@@ -42,14 +42,30 @@ proper_motion:
   pmra_ep: 0.0141
   ref_proper_motion: Sohn2020ApJ...901...43S
 structure:
-  ellipticity: 0.15
-  ellipticity_em: 0.1
-  ellipticity_ep: 0.1
-  position_angle: 35.0
-  position_angle_em: 3.0
-  position_angle_ep: 3.0
-  ref_structure: McConnachie2012AJ....144....4M
-  rhalf: 2.55
+  ellipticity: 0.22
+  ellipticity_em: 0.01
+  ellipticity_ep: 0.01
+  position_angle: 45.9
+  position_angle_em: 1.2
+  position_angle_ep: 1.2
+  rhalf: 2.94
+  rhalf_em: 0.04
+  rhalf_ep: 0.04
+  ref_structure: Crnojević2014MNRAS.445.3862C
+structure_sersic:
+  n_sersic: 1.78
+  n_sersic_em: 0.02
+  n_sersic_ep: 0.02
+  ellipticity: 0.22
+  ellipticity_em: 0.01
+  ellipticity_ep: 0.01
+  position_angle: 45.9
+  position_angle_em: 1.2
+  position_angle_ep: 1.2
+  rad_sersic: 2.94
+  rad_sersic_em: 0.04
+  rad_sersic_ep: 0.04
+  ref_structure_sersic: Crnojević2014MNRAS.445.3862C
 velocity:
   ref_vlos: McConnachie2012AJ....144....4M
   vlos_sigma: 24.0

--- a/data_input/ngc_0185.yaml
+++ b/data_input/ngc_0185.yaml
@@ -29,7 +29,7 @@ flux_HI:
   flux_HI_ep: 0.11
   ref_flux_HI: Putman2021ApJ...913...53P
 m_v:
-  apparent_magnitude_v: 8.76
+  apparent_magnitude_v: 8.46
   apparent_magnitude_v_em: 0.04
   apparent_magnitude_v_ep: 0.04
   ref_m_v: Crnojević2014MNRAS.445.3862C

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -85,7 +85,7 @@ Columns:
 * confirmed_star_cluster: system is confirmed to be a star cluster.
 * ra: right ascension ICRS J2000.0 [degree]
 * dec: declination ICRS J2000.0 [degree]
-* rhalf: projected (2D) major axis of the half-light radius (or plummer radius) in [arcmin]. Note that input yaml files can have arcsec or arcmin input units but the combined catalogs are in arcmin. 
+* rhalf: projected (2D) semi-major axis of the half-light ellipse defined by `ellipticity` and `position_angle` in units of [arcmin]. Note that input yaml files can have arcsec or arcmin input units but the combined catalogs are in arcmin. 
 * ellipticity: 1 - minor/major axis (or 1 - axis ratio).
 * position_angle: N->E [degree] 
 * distance_modulus [mag]

--- a/table/lvdb.bib
+++ b/table/lvdb.bib
@@ -16626,7 +16626,23 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-
+@ARTICLE{Crnojevic2014MNRAS.445.3862C,
+       author = {{Crnojevi{\'c}}, D. and {Ferguson}, A.~M.~N. and {Irwin}, M.~J. and {McConnachie}, A.~W. and {Bernard}, E.~J. and {Fardal}, M.~A. and {Ibata}, R.~A. and {Lewis}, G.~F. and {Martin}, N.~F. and {Navarro}, J.~F. and {No{\"e}l}, N.~E.~D. and {Pasetto}, S.},
+        title = "{A PAndAS view of M31 dwarf elliptical satellites: NGC 147 and NGC 185}",
+      journal = {\mnras},
+     keywords = {galaxies: dwarf, galaxies: evolution, galaxies: individual: NGC 147, galaxies: individual: NCG 185, Local Group, galaxies: photometry, Astrophysics - Astrophysics of Galaxies},
+         year = 2014,
+        month = dec,
+       volume = {445},
+       number = {4},
+        pages = {3862-3877},
+          doi = {10.1093/mnras/stu2003},
+archivePrefix = {arXiv},
+       eprint = {1409.7065},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014MNRAS.445.3862C},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 
 


### PR DESCRIPTION
https://ui.adsabs.harvard.edu/abs/2014MNRAS.445.3862C/abstract

I set rhalf = reff from their Table 2 (Sersic fits), they do the fit in projected elliptical radii `r = sqrt(x^2 + (y / (1 - ellip))^2)` so I think their reff should be equivalent to your `rhalf` definition. If not let me know and I can change it

I also revised the docs on the definition of `rhalf` to make it clearer (IMO), let me know if you want me to revert it.